### PR TITLE
Positioning/scroll fix

### DIFF
--- a/addon/components/modal-dialog.js
+++ b/addon/components/modal-dialog.js
@@ -24,16 +24,25 @@ export default ModalDialog.extend({
     didInsertElement() {
         this._super(...arguments);
         $(document).on('keyup.modal-dialog', bind(this, '_escapeListener'));
+        $(document).on('click.modal-dialog', '.modal', bind(this, '_modalClickListener'));
         $('body').addClass('modal-open');
     },
     willDestroyElement() {
         this._super(...arguments);
-        $(document).off('keyup.modal-dialog');
+        $(document).off('.modal-dialog');
         later($('body'), 'removeClass', 'modal-open', get(this, 'modal.animationDuration'));
     },
     _escapeListener(event) {
         if (event.keyCode === ESC_KEY && get(this, 'closable')) {
             tryInvoke(this, 'onClose');
+        }
+    },
+    _modalClickListener(event) {
+        //clicks directly on the modal container should behave as clicks on the overlay backdrop
+        //this is necessary because bootstrap's .modal container stretches to cover the entire viewport
+        //and has a higher z-index ordering than the overlay backdrop
+        if($(event.target).is('.modal')) {
+            this.actions.onClickOverlay.apply(this, [event]);
         }
     }
 });

--- a/addon/components/modal-dialog.js
+++ b/addon/components/modal-dialog.js
@@ -16,6 +16,7 @@ export default ModalDialog.extend({
         return `modal-backdrop animated ${get(this, 'modal.animation') && get(this, 'modal.animation').includes('In') ? 'fadeIn' : 'fadeOut' }`;
     }),
     overlayPosition: 'sibling',
+    targetAttachment: null,
     translucentOverlay: true,
     hasOverlay: true,
     closable: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gavant-ember-modals",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Modal components built on ember-modal-dialog.",
   "author": "Gavant Software, Inc.",
   "repository": "https://github.com/Gavant/gavant-ember-modals",

--- a/tests/dummy/app/templates/components/modal-dialogs/test-modal.hbs
+++ b/tests/dummy/app/templates/components/modal-dialogs/test-modal.hbs
@@ -1,7 +1,11 @@
 {{#modal-dialog onClose=onClose size="sm" as |modal|}}
   {{modal.header title="test"}}
   {{#modal.body}}
-      <p>Test Modal</p>
+      <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur placerat sem non orci posuere, eget porta augue accumsan. Integer eget elementum dolor. Mauris id augue eget nibh molestie euismod et id tortor. Fusce at massa purus. Nam vel metus cursus turpis finibus iaculis sed sit amet justo. Integer luctus, sem et tempor pharetra, mi sem aliquet erat, at fermentum orci magna eu augue. Quisque eget nunc velit. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Maecenas ut lorem vitae nisi ultrices finibus. Vestibulum facilisis erat in nisi mattis, facilisis posuere ex euismod. Morbi aliquam rutrum eros. In diam orci, sollicitudin non velit vitae, blandit facilisis sapien. Praesent placerat nec turpis et pretium. Cras eu est a urna porttitor mattis. Aliquam iaculis libero massa, eget congue metus sodales a. Donec vestibulum dapibus finibus.
+
+Nullam eget dui ac dolor pretium convallis. Fusce sit amet dignissim nunc, ut varius elit. Nullam facilisis id neque vel vehicula. Phasellus sed sem ac diam lacinia accumsan. Interdum et malesuada fames ac ante ipsum primis in faucibus. In blandit lorem a consequat posuere. Etiam tristique neque at massa porta dictum. Etiam sed lorem cursus, egestas nisi id, molestie felis. Phasellus ac ligula ex. Quisque vehicula neque eget tellus feugiat placerat. Cras ultricies rutrum magna a tincidunt. Duis accumsan velit a ipsum efficitur, sit amet maximus dui venenatis. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Vestibulum consectetur, est id aliquam lacinia, felis nisl accumsan est, a commodo massa ipsum ut ligula. Fusce ac varius magna.
+      </p>
       {{day}}
   {{/modal.body}}
   {{#modal.footer}}


### PR DESCRIPTION
In cases where the a modal is big enough (or the window is small enough) for the viewport to scroll, the modal container layout was messed up and showing a scrollbar inset in the middle of the page. 

This was due to ember-modal-dialog's own positioning logic (using ember-tether) conflicting with Bootstrap's modal positioning styles (which are to align the modal to the top of the page instead of being vertically centered). I just disabled the ember-tether positioning by default, but this could be re-enabled in apps if they so desire (but would then need to resolve the bootstrap layout conflicts as well).

There was an additional bug (that was somewhat less noticeable with the previous ember-tether based positioning, but still present) where clicks on certain areas surrounding the modal would not trigger a close of the modal. This is due to the `.modal` container element being ordered above the overlay backdrop element, such that the backdrop was not receiving the clicks. (I initially tried a simple `pointer-events:none` on the .modal which worked, but had the issue of breaking scrolling)