### PR TITLE
Promise on close

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,119 @@ ember install gavant-ember-modals
 
 Usage
 ------------------------------------------------------------------------------
-
 To use the addon styles, you must use SASS:
 ```
 ember install ember-cli-sass
 ```
 
 (Upon addon installation, an import statement will be added to your `app.scss`)
+
+`gavant-ember-modals` gives you multiple different components for extensibility.
+
+First you should add `modal-outlet` to your application template
+```
+{{modal-outlet}}
+```
+
+Next create a component for your modal. By default we look for it under `modal-dialogs`.
+So when you generate your component you would use something like This
+```
+ember g component modal-dialogs/add-email
+```
+
+Component
+```
+import Component from '@ember/component';
+import { tryInvoke } from '@ember/utils';
+import SpreadMixin from 'ember-spread'
+import { get } from '@ember/object';
+
+export default Component.extend(SpreadMixin, {
+    actions: {
+        async save(changeset) {
+            try {
+                const result = await changeset.save();
+                await tryInvoke(this, 'onClose');
+                return result;
+            } catch(errors) {
+                //Do something with error
+            }
+        }
+    }
+});
+```
+
+Template
+```
+{{#modal-dialog onClose=onClose size="sm" as |modal|}}
+    {{modal.header title=title}}
+    {{#modal.body}}
+        {{#form-validator
+            changeset=changeset
+            submit=(action "save")
+            as |changeset validator|
+        }}
+            {{#input-validator target="emailAddress" text="Email"}}
+                {{fl-input
+                    value=changeset.emailAddress
+                    type="text"
+                    placeholder="Email"
+                    maxlength="200"
+                }}
+            {{/input-validator}}
+            {{#modal.footer}}
+                {{button-basic
+                    type="link"
+                    label=(t "action.cancel")
+                    action=modal.close
+                }}
+                {{button-spinner
+                    type="primary"
+                    class="px-4"
+                    label=(t "action.save")
+                    action=validator.submit
+                }}
+            {{/modal.footer}}
+        {{/form-validator}}
+    {{/modal.body}}
+{{/modal-dialog}}
+```
+
+and now open the modal by injecting the modal service provided into the controller that needs it
+and call the modal services `open` method using the name of the modal you created earlier
+
+```
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+
+export default Controller.extend({
+    modal: service(),
+    actions: {
+        addEmail() {
+            get(this, 'modal').open('add-email', {
+                title: "Add Email"
+            });
+        }
+    }
+});
+
+```
+
+Options
+There are some different useful optional ways to use modals that might be of use to you.
+
+1) `await tryInvoke(this, 'onClose');` 
+The onClose event returns a promise when the modal is finished closing (after animating out) so if you need to do something afterwards, you can wait for that event to finish.
+2) You can pass in actions to call inside the modal from the controller that is opening the modal. You do this by adding an `actions` hash to the open options i.e.
+```
+get(this, 'modal').open('add-email', {
+    title: "Add Email",
+    actions: {
+        doSomething: bind(this, 'doSomething')
+    }
+});
+```
+then in the modal you can just call `await tryInvoke(this, 'doSomething');`
 
 
 Contributing

--- a/addon/components/modal-outlet.js
+++ b/addon/components/modal-outlet.js
@@ -35,7 +35,7 @@ const ModalOutlet = Component.extend({
     },
 
     closeModal() {
-        this.get('modal').close();
+        return this.get('modal').close();
     },
 
     willDestroyElement() {
@@ -61,7 +61,7 @@ const ModalOutlet = Component.extend({
 
     actions: {
         close() {
-            this.closeModal();
+            return this.closeModal();
         }
     }
 });

--- a/addon/services/modal.js
+++ b/addon/services/modal.js
@@ -24,7 +24,7 @@ export default Service.extend(Evented, {
     },
 
     close() {
-        return Promise(resolve => {
+        return Promise(function(resolve) {
             set(this, 'animation', get(this, 'animationOut'));
             later(this, () => {
                 const modal = get(this, 'current');

--- a/addon/services/modal.js
+++ b/addon/services/modal.js
@@ -24,7 +24,7 @@ export default Service.extend(Evented, {
     },
 
     close() {
-        return Promise(function(resolve) {
+        return new Promise(function(resolve) {
             set(this, 'animation', get(this, 'animationOut'));
             later(this, () => {
                 const modal = get(this, 'current');

--- a/addon/services/modal.js
+++ b/addon/services/modal.js
@@ -24,7 +24,7 @@ export default Service.extend(Evented, {
     },
 
     close() {
-        return new Promise(function(resolve) {
+        return new Promise((resolve) => {
             set(this, 'animation', get(this, 'animationOut'));
             later(this, () => {
                 const modal = get(this, 'current');

--- a/addon/services/modal.js
+++ b/addon/services/modal.js
@@ -4,6 +4,7 @@ import { set, get, setProperties } from '@ember/object';
 import { later } from '@ember/runloop';
 import { notEmpty } from '@ember/object/computed';
 import { A } from '@ember/array';
+import { Promise } from 'rsvp';
 
 export default Service.extend(Evented, {
     animationIn: 'zoomIn',
@@ -23,13 +24,17 @@ export default Service.extend(Evented, {
     },
 
     close() {
-        set(this, 'animation', get(this, 'animationOut'));
-        later(this, () => {
-            const modal = get(this, 'current');
-            set(this, 'current', null);
-            this.trigger('closed', modal);
-            this.processQueue();
-        }, get(this, 'animationDuration'));
+        return Promise(resolve => {
+            set(this, 'animation', get(this, 'animationOut'));
+            later(this, () => {
+                const modal = get(this, 'current');
+                //Set current modal to null, trigger closed event and resolve close promise
+                set(this, 'current', null);
+                this.trigger('closed', modal);
+                resolve();
+                this.processQueue();
+            }, get(this, 'animationDuration'));
+        });
     },
 
     processQueue() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gavant-ember-modals",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Modal components built on ember-modal-dialog.",
   "author": "Gavant Software, Inc.",
   "repository": "https://github.com/Gavant/gavant-ember-modals",


### PR DESCRIPTION
This PR solves 2 issues.
1) Adding missing documentation
2) Needed a way to wait to do an action until the modal was fully closed. So now we resolve and return a promise when modal has finished animating out.